### PR TITLE
Ajout de pages pour planifier le voyage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "leaflet": "^1.9.4",
         "next": "14.1.0",
         "next-themes": "^0.4.6",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-leaflet": "^4.2.1"
       },
       "devDependencies": {
         "@types/node": "^20.11.24",
@@ -497,6 +499,17 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3612,6 +3625,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4423,6 +4442,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,22 +9,24 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
+    "leaflet": "^1.9.4",
     "next": "14.1.0",
+    "next-themes": "^0.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@heroicons/react": "^2.2.0",
-    "next-themes": "^0.4.6"
+    "react-leaflet": "^4.2.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",
     "@types/react": "^18.2.61",
     "@types/react-dom": "^18.2.19",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.1.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.3.3",
-    "@typescript-eslint/eslint-plugin": "^6.21.0"
+    "typescript": "^5.3.3"
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import url('leaflet/dist/leaflet.css');
 
 :root {
   --foreground-rgb: 0, 0, 0;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,6 +27,11 @@ export default function RootLayout({
               <Link href="/discoveries" className="hover:underline">Découvertes</Link>
               <Link href="/tips" className="hover:underline">Conseils</Link>
               <Link href="/todo" className="hover:underline">Todo</Link>
+              <Link href="/map" className="hover:underline">Carte</Link>
+              <Link href="/packing-list" className="hover:underline">Bagages</Link>
+              <Link href="/payments" className="hover:underline">Paiements</Link>
+              <Link href="/weather" className="hover:underline">Météo</Link>
+              <Link href="/news" className="hover:underline">Actualités</Link>
             </div>
           </div>
         </nav>

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useEffect, useState } from 'react'
+import 'leaflet/dist/leaflet.css'
+
+const MapContainer = dynamic<any>(() => import('react-leaflet').then(mod => mod.MapContainer), { ssr: false })
+const TileLayer = dynamic<any>(() => import('react-leaflet').then(mod => mod.TileLayer), { ssr: false })
+const Marker = dynamic<any>(() => import('react-leaflet').then(mod => mod.Marker), { ssr: false })
+const Popup = dynamic<any>(() => import('react-leaflet').then(mod => mod.Popup), { ssr: false })
+
+interface Place {
+  position: [number, number]
+  name: string
+}
+
+export default function MapPage() {
+  const [isClient, setIsClient] = useState(false)
+  useEffect(() => { setIsClient(true) }, [])
+
+  const places: Place[] = [
+    { position: [55.6761, 12.5683], name: 'Centre-ville' },
+    { position: [55.67394, 12.56553], name: 'Steel House Copenhagen' },
+    { position: [55.6839, 12.5948], name: 'Noma' },
+    { position: [55.6733, 12.5681], name: 'Tivoli Gardens' },
+  ]
+
+  if (!isClient) return null
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Carte des lieux</h1>
+      <MapContainer center={[55.6761, 12.5683]} zoom={13} style={{ height: '500px', width: '100%' }}>
+        <TileLayer
+          attribution="&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        {places.map((p, idx) => (
+          <Marker position={p.position} key={idx}>
+            <Popup>{p.name}</Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
+  )
+}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Article {
+  title: string
+  url: string
+}
+
+export default function NewsPage() {
+  const [articles, setArticles] = useState<Article[]>([])
+
+  useEffect(() => {
+    fetch('https://hn.algolia.com/api/v1/search?query=copenhagen')
+      .then(r => r.json())
+      .then(json => {
+        const arr = json.hits.slice(0,5).map((h: any) => ({ title: h.title, url: h.url }))
+        setArticles(arr)
+      })
+      .catch(() => {})
+  }, [])
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Actualités récentes</h1>
+      <ul className="list-disc pl-5 space-y-2">
+        {articles.map((a, idx) => (
+          <li key={idx}>
+            <a href={a.url} className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">
+              {a.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/packing-list/page.tsx
+++ b/src/app/packing-list/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState } from 'react'
+
+const defaultItems = [
+  'Passeport',
+  'Billets d\'avion',
+  'Vêtements chauds',
+  'Chargeur',
+  'Adaptateur prise',
+]
+
+export default function PackingList() {
+  const [items, setItems] = useState(defaultItems.map(i => ({ name: i, checked: false })))
+
+  const toggle = (idx: number) => {
+    const newItems = [...items]
+    newItems[idx].checked = !newItems[idx].checked
+    setItems(newItems)
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Liste de choses à emporter</h1>
+      <ul className="space-y-2">
+        {items.map((item, idx) => (
+          <li key={idx} className="flex items-center space-x-2">
+            <input type="checkbox" checked={item.checked} onChange={() => toggle(idx)} />
+            <span className={item.checked ? 'line-through' : ''}>{item.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/payments/page.tsx
+++ b/src/app/payments/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useState } from 'react'
+
+const people = ['Chaima', 'Erton', 'Agathe', 'Mathis']
+const installments = [1,2,3,4]
+
+export default function Payments() {
+  const [payments, setPayments] = useState(() => (
+    people.map(p => installments.map(i => ({ person: p, installment: i, paid: false })))
+  ))
+
+  const toggle = (pIdx: number, iIdx: number) => {
+    const newData = payments.map(arr => arr.slice())
+    newData[pIdx][iIdx].paid = !newData[pIdx][iIdx].paid
+    setPayments(newData)
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Suivi des paiements logement</h1>
+      <table className="min-w-full border divide-y">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Personne</th>
+            {installments.map(n => (
+              <th key={n} className="px-2 py-1">Versement {n}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {payments.map((row, pIdx) => (
+            <tr key={people[pIdx]} className="text-center">
+              <td className="border px-2 py-1">{people[pIdx]}</td>
+              {row.map((it, iIdx) => (
+                <td key={iIdx} className="border px-2 py-1">
+                  <input type="checkbox" checked={it.paid} onChange={() => toggle(pIdx, iIdx)} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/weather/page.tsx
+++ b/src/app/weather/page.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface WeatherDay {
+  date: string
+  tmin: number
+  tmax: number
+  rain: number
+}
+
+export default function WeatherPage() {
+  const [data, setData] = useState<WeatherDay[]>([])
+
+  useEffect(() => {
+    fetch('https://api.open-meteo.com/v1/forecast?latitude=55.6761&longitude=12.5683&daily=temperature_2m_max,temperature_2m_min,precipitation_probability_mean&timezone=Europe%2FCopenhagen')
+      .then(res => res.json())
+      .then(json => {
+        const days = json.daily
+        const arr: WeatherDay[] = days.time.map((t: string, idx: number) => ({
+          date: t,
+          tmin: days.temperature_2m_min[idx],
+          tmax: days.temperature_2m_max[idx],
+          rain: days.precipitation_probability_mean[idx],
+        }))
+        setData(arr)
+      })
+      .catch(() => {})
+  }, [])
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Météo prévue</h1>
+      <table className="min-w-full divide-y">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Date</th>
+            <th className="px-2 py-1">Min °C</th>
+            <th className="px-2 py-1">Max °C</th>
+            <th className="px-2 py-1">Pluie %</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map(d => (
+            <tr key={d.date} className="text-center border-t">
+              <td className="px-2 py-1">{d.date}</td>
+              <td className="px-2 py-1">{d.tmin}</td>
+              <td className="px-2 py-1">{d.tmax}</td>
+              <td className="px-2 py-1">{d.rain}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- install `react-leaflet` et `leaflet`
- ajout d'une carte interactive avec quelques lieux
- nouvelle liste d'objets à emporter
- suivi des paiements du logement
- affichage météo via API Open-Meteo
- affichage d'actualités depuis HN
- mise à jour de la navigation et des styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ffc1c1d2c832a85918a65c924438a