### PR TITLE
Fix build issues on Infomaniak

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,9 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   output: 'export',
-  experimental: {
-    appDir: true
-  }
+  // App Router is enabled by default in Next.js 14
 }
 
-module.exports = nextConfig 
+module.exports = nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "leaflet": "^1.9.4",
         "next": "14.1.0",
         "next-themes": "^0.4.6",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
         "react-leaflet": "^4.2.1"
       },
       "devDependencies": {
@@ -592,6 +592,8 @@
     },
     "node_modules/@react-leaflet/core": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
       "license": "Hippocratic-2.1",
       "peerDependencies": {
         "leaflet": "^1.9.0",
@@ -4298,7 +4300,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -4308,14 +4312,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "leaflet": "^1.9.4",
     "next": "14.1.0",
     "next-themes": "^0.4.6",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-leaflet": "^4.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove obsolete `experimental.appDir` setting from `next.config.js`
- pin `react` and `react-dom` to 18.2.0 to avoid mismatched peer versions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68400c33e320832aaff7f7435ff5b134