### PR TITLE
Fix lint rule in PostCSS config

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,8 @@
-export default {
+const config = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
 };
+
+export default config;


### PR DESCRIPTION
## Summary
- assign PostCSS options to a named variable

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684181c85d98832ab5a76c6801540955