### PR TITLE
Update deploy workflow to just FTP upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,16 +17,7 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Install dependencies and build
-        run: npm ci && npm run build
-      
-      # Préparer les fichiers à déployer
-      - name: Prepare files for deployment
-        run: |
-          mkdir -p deploy
-          cp -r .next public deploy/
-          cp package.json package-lock.json deploy/
-          if [ -f server.js ]; then cp server.js deploy/; fi
+      # Les étapes de build sont omises pour transférer le projet tel quel
           
       # Déployer sur Infomaniak
       - name: Deploy to Infomaniak
@@ -35,7 +26,7 @@ jobs:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
-          local-dir: ./deploy/
+          local-dir: ./
           server-dir: ${{ secrets.FTP_SERVER_DIR }}
           dangerous-clean-slate: false
           # Vous pourriez vouloir exclure .git, .github, etc.


### PR DESCRIPTION
## Summary
- simplify workflow by removing install and build steps
- deploy project as-is via FTP

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68419d44ac18832aa83717a2552688a9