### PR TITLE
Fix static site serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,20 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Production build
+
+To generate the static site and serve it locally:
+
+```bash
+# install dependencies if needed
+npm install
+
+# build and export the site to the `out` directory
+npm run build
+
+# serve the exported files
+node server.js
+```
+
+`node server.js` simply serves the files from the `out` folder using Express. You can also use `npx serve out` or any other static file server.

--- a/server.js
+++ b/server.js
@@ -3,8 +3,8 @@ const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 
-// Servir les fichiers statiques depuis le dossier racine
-app.use(express.static('.'));
+// Serve static files from the Next.js export directory
+app.use(express.static(path.join(__dirname, 'out')));
 
 // Gérer les routes SPA (Single Page Application)
 app.get('*', (req, res) => {
@@ -14,7 +14,7 @@ app.get('*', (req, res) => {
   }
   
   // Pour toutes les autres routes, servir index.html
-  res.sendFile(path.join(__dirname, 'index.html'));
+  res.sendFile(path.join(__dirname, 'out', 'index.html'));
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- serve static files from the `out` directory
- document how to build and run in production

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685171c37dd4832ab6bfdd074e1d9ec7