### PR TITLE
Update build and start scripts for Infomaniak

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Deploy on Infomaniak
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+To deploy the pre-built application on [Infomaniak](https://www.infomaniak.com/):
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+1. Install the dependencies with `npm install`.
+2. Build the static site with `npm run build`. The generated files will be placed in the `out` directory.
+3. Start the Express server with `npm start`.
+
+The server serves the files from the `out` folder and will be ready on the configured port (default `3000`).

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node server.js",
     "lint": "next lint"
   },
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -3,18 +3,13 @@ const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 
-// Servir les fichiers statiques depuis le dossier racine
-app.use(express.static('.'));
+// Servir les fichiers statiques générés par Next.js dans le dossier "out"
+app.use(express.static(path.join(__dirname, 'out')));
 
 // Gérer les routes SPA (Single Page Application)
 app.get('*', (req, res) => {
-  // Si c'est une route d'API ou un fichier, ne pas rediriger
-  if (req.url.startsWith('/_next') || req.url.includes('.')) {
-    return res.status(404).send('Not found');
-  }
-  
-  // Pour toutes les autres routes, servir index.html
-  res.sendFile(path.join(__dirname, 'index.html'));
+  // Pour toutes les autres routes, servir le fichier index.html généré
+  res.sendFile(path.join(__dirname, 'out', 'index.html'));
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- serve the static export with Express
- update start script to use `server.js`
- document build & start steps for Infomaniak

## Testing
- `npm run lint`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6851766e6d2c832a85037382d4510ae3